### PR TITLE
Tags to front

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -79,3 +79,18 @@ text-align: center;
 color: #000000;
 
 }
+
+
+.tag {
+    color: rgb(41, 36, 36);
+    list-style-type: none; 
+    display: inline-block;
+    background-color: #cde1e9;
+    margin-right: 0.25rem;
+    padding: 0.25rem;
+    border-radius: 0.25rem;
+}
+
+ul {
+    padding-left: 0;
+}

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -5,7 +5,7 @@ h1{
     text-decoration: line-through;
     color: gray;
 }
-.not{
+.links{
     text-decoration: underline;
 }
 #topLogo{

--- a/views/links.ejs
+++ b/views/links.ejs
@@ -23,7 +23,13 @@
     <ul>
     <% links.forEach( el => { %>
             <li class='linkItem' data-id='<%=el._id%>'>
-              <a target="_blank" href="<%= el.link %>" class='links'>'>%><span class='<%= el.completed === true ? 'completed' : 'not'%>'><%= el.title %></span></a>
+              <a target="_blank" href="<%= el.link %>"><span class='links'><%= el.title %></span></a>
+              <ul>
+                <% el.tags.forEach( tag => { %> 
+                    <li class="tag"> <%= tag %> </li>
+                <% }) %>
+              </ul>
+
               <span class='del'> Delete </span>
             </li>
     <% }) %>    

--- a/views/links.ejs
+++ b/views/links.ejs
@@ -23,8 +23,8 @@
     <ul>
     <% links.forEach( el => { %>
             <li class='linkItem' data-id='<%=el._id%>'>
-              <a target="_blank" href="<%= el.link %>" class='<%= el.completed === true ? 'completed' : 'not'%>'>%><span class='<%= el.completed === true ? 'completed' : 'not'%>'><%= el.title %></span></a>
-                <span class='del'> Delete </span>
+              <a target="_blank" href="<%= el.link %>" class='links'%>'>%><span class='<%= el.completed === true ? 'completed' : 'not'%>'><%= el.title %></span></a>
+              <span class='del'> Delete </span>
             </li>
     <% }) %>    
     </ul>

--- a/views/links.ejs
+++ b/views/links.ejs
@@ -23,7 +23,7 @@
     <ul>
     <% links.forEach( el => { %>
             <li class='linkItem' data-id='<%=el._id%>'>
-              <a target="_blank" href="<%= el.link %>" class='links'%>'>%><span class='<%= el.completed === true ? 'completed' : 'not'%>'><%= el.title %></span></a>
+              <a target="_blank" href="<%= el.link %>" class='links'>'>%><span class='<%= el.completed === true ? 'completed' : 'not'%>'><%= el.title %></span></a>
               <span class='del'> Delete </span>
             </li>
     <% }) %>    


### PR DESCRIPTION
-Added client-side logic in links.ejs to display each link's tags under it.
![image](https://user-images.githubusercontent.com/87082240/188334030-b51ac887-8f66-4043-971a-599f6598a6f5.png)

-Removed redundant client-side code applying 'completed' or 'not' classes to links. Replaced with class 'links'
![image](https://user-images.githubusercontent.com/87082240/188334017-f2535f35-fec7-4a3c-9c92-3dba98cf676a.png)

-----------

-Changed .not to .links
![image](https://user-images.githubusercontent.com/87082240/188334054-76f46174-15eb-4084-aef8-4d8745631d55.png)

-Added basic styling for tags. Feel free to remove or change
![image](https://user-images.githubusercontent.com/87082240/188334069-a650a113-2967-4c86-8fb6-f657d9dafd64.png)

-Removed padding-left from uls
![image](https://user-images.githubusercontent.com/87082240/188334082-c1e74ce6-5e3f-4229-8061-d580a0d25903.png)
